### PR TITLE
add merging functionality when downloading historical data for tickers

### DIFF
--- a/bvb_finance/constants.py
+++ b/bvb_finance/constants.py
@@ -12,3 +12,6 @@ historical_prices = 'historical_prices'
 portfolio_data_path = Path(__file__).parent.parent / portfolio_data
 root_dir = portfolio_data_path
 portfolio_historical_data_path = portfolio_data_path / historical_prices
+
+portfolio_data_path.mkdir(mode=0o777, parents=True, exist_ok=True)
+portfolio_historical_data_path.mkdir(mode=0o777, parents=True, exist_ok=True)

--- a/bvb_finance/portfolio/dto.py
+++ b/bvb_finance/portfolio/dto.py
@@ -52,10 +52,15 @@ class HistoricalDataDict(typing.TypedDict):
 
 class HistoricalData(common_dto.DictConverter):
     @staticmethod
-    def convert_date_from_str(value: str | datetime.date) -> datetime.date:
+    def convert_date_from_str(value: str | datetime.date | pd.Timestamp) -> datetime.date:
+        if isinstance(value, pd.Timestamp):
+            return value.date()
         if isinstance(value, datetime.date):
             return value
-        return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S").date()
+        try:
+            return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S").date()
+        except ValueError:
+            return datetime.datetime.strptime(value, "%Y-%m-%d").date()
 
     @staticmethod
     def convert_symbol_from_trading_view_format(symbol: str) -> str:

--- a/bvb_finance/portfolio/loaders.py
+++ b/bvb_finance/portfolio/loaders.py
@@ -7,19 +7,13 @@ import datetime
 import pandas as pd
 from bvb_finance import logging
 from bvb_finance import constants
-from tvDatafeed import TvDatafeed, Interval
+from bvb_finance.portfolio.trading_view import perform_data_transfomration  
 
 logger = logging.getLogger()
 
 root_path = pathlib.Path(__file__).parent.parent.parent
 portfolio_acquisition_details = root_path / 'resources/portfolio_acquisition_details_by_date.tsv'
 portfolio_stock_splits = root_path / 'resources/stock_splits.tsv'
-
-TradingViev = TvDatafeed()
-TRADINGVIEW_BVB_SYMBOL='BVB'
-
-constants.portfolio_data_path.mkdir(mode=0o777, parents=True, exist_ok=True)
-constants.portfolio_historical_data_path.mkdir(mode=0o777, parents=True, exist_ok=True)
 
 def load_acquisitions_data(path: pathlib.Path) -> pd.DataFrame :
     if not path.exists():
@@ -37,42 +31,6 @@ def load_stock_splits_data(path: pathlib.Path) -> pd.DataFrame :
     logger.info(f'Successfuly loaded stock splits data from {path.as_posix()}')
     return df
 
-def perfomr_data_transfomration(df: pd.DataFrame):
-    columns = list(df.columns)
-    if 'datetime' not in columns:
-        return
-    logger.info("Performing data transformation for columns [datetime, symbol]")
-    df['datetime'] = df['datetime'].apply(dto.HistoricalData.convert_date_from_str)
-    df['symbol'] = df['symbol'].apply(dto.HistoricalData.convert_symbol_from_trading_view_format)
-    df.rename(columns={'datetime': 'date'}, inplace=True)
-
-def download_historical_data_single_ticker(ticker: str) -> pd.DataFrame:
-    file = (constants.portfolio_historical_data_path / ticker).with_suffix(".csv")
-    if file.exists():
-        logger.warn(f"Skipping downloading historical data for {ticker}. Already exists: {file.as_posix()}")
-        return pd.read_csv(file, index_col=False)
-    
-    logger.info(f"Getting trading view data for ticker {ticker}")
-    df: pd.DataFrame = TradingViev.get_hist(
-        symbol=ticker,
-        exchange=TRADINGVIEW_BVB_SYMBOL,
-        interval=Interval.in_weekly,
-        n_bars=500)
-    if df is None:
-        logger.warn(f"Failed to download trading view data for {ticker}")
-        return pd.DataFrame()
-    df.reset_index(inplace=True)
-
-    perfomr_data_transfomration(df)
-    
-    logger.info(f"Saving dataframe to {file.as_posix()}")
-    df.to_csv(file, index=False)
-    return df
-
-def download_historical_data(tickers: list[str]):
-    for ticker in tickers:
-        download_historical_data_single_ticker(ticker)
-
 def load_historical_data_single_ticker(ticker: str | pathlib.Path) -> None | pd.DataFrame:
     file = (constants.portfolio_historical_data_path / ticker).with_suffix(".csv")
     ticker = file.name.split(".")[0]
@@ -81,7 +39,7 @@ def load_historical_data_single_ticker(ticker: str | pathlib.Path) -> None | pd.
         return
     logger.info(f"Loadibg historical data for {ticker}")
     df: pd.DataFrame = pd.read_csv(file, index_col=False)
-    perfomr_data_transfomration(df)
+    perform_data_transfomration(df)
     return df
 
 def load_historical_data_many_tickers(tickers: list[str]) -> dto.MarketData:

--- a/bvb_finance/portfolio/trading_view.py
+++ b/bvb_finance/portfolio/trading_view.py
@@ -1,0 +1,154 @@
+import datetime
+import pandas as pd
+import typing
+import concurrent.futures
+from pathlib import Path
+from bvb_finance import logging
+from bvb_finance import constants
+from bvb_finance.portfolio import dto
+from tvDatafeed import TvDatafeed, Interval
+
+logger = logging.getLogger()
+
+TradingViev = TvDatafeed()
+TRADINGVIEW_BVB_SYMBOL='BVB'
+
+def perform_data_transfomration(df: pd.DataFrame):
+    columns = list(df.columns)
+    if 'datetime' in columns:
+        logger.info("Performing data transformation for columns [datetime, symbol]")
+        df['datetime'] = df['datetime'].apply(dto.HistoricalData.convert_date_from_str)
+        df['symbol'] = df['symbol'].apply(dto.HistoricalData.convert_symbol_from_trading_view_format)
+        df.rename(columns={'datetime': 'date'}, inplace=True)
+    else:
+        # if date is saved as str convert it to datetime.date
+        df['date'] = df['date'].apply(dto.HistoricalData.convert_date_from_str)
+
+def download_trading_view_data(ticker: str) -> pd.DataFrame:
+    df: pd.DataFrame = TradingViev.get_hist(
+        symbol=ticker,
+        exchange=TRADINGVIEW_BVB_SYMBOL,
+        interval=Interval.in_weekly,
+        n_bars=500)
+    if df is None:
+        logger.warn(f"Failed to download trading view data for {ticker}")
+        return pd.DataFrame()
+    df.reset_index(inplace=True)
+    return df
+
+def get_portfolio_historical_data_csv(ticker: str) -> Path:
+    return (constants.portfolio_historical_data_path / ticker).with_suffix(".csv")
+
+def download_historical_data_single_ticker(ticker: str) -> pd.DataFrame:
+    file = get_portfolio_historical_data_csv(ticker)
+    if file.exists():
+        logger.warn(f"Skipping downloading historical data for {ticker}. Already exists: {file.as_posix()}")
+        return pd.read_csv(file, index_col=False)
+    
+    logger.info(f"Getting trading view data for ticker {ticker}")
+
+    df = download_trading_view_data(ticker)
+    perform_data_transfomration(df)
+    
+    logger.info(f"Saving dataframe to {file.as_posix()}")
+    df.to_csv(file, index=False)
+    return df
+
+def is_sorted_by_date(date_list: list[datetime.date]) -> bool:
+    if len(date_list) == 0:
+        return True
+    if not isinstance(date_list[0], datetime.date):
+        logger.warm(f"Expected datetime.date in list data. but was {type(date_list[0])}: list data {date_list}")
+        return False
+    sorted_date_list = sorted(date_list)
+    return sorted_date_list == date_list
+
+def merge_dataframes(first: pd.DataFrame, second: pd.DataFrame) -> pd.DataFrame:
+    if first.empty:
+        return second
+    if second.empty:
+        return first
+    first_columns = list(first.columns)
+    second_columns = list(second.columns)
+    if first_columns != second_columns:
+        logger.warn(f'Cannot merge dataframe with columns {first_columns} with dataframe with diferent columns {second_columns}')
+        return
+    first_timestamps = list(first['date'])
+    second_timestamps = list(second['date'])
+    new_dates = [s for s in second_timestamps if s not in first_timestamps]
+
+    filtered_df = second.loc[second['date'].apply(lambda x: x in new_dates), :]
+    result: pd.DataFrame = pd.concat([first, filtered_df])
+    result.sort_values(by=['date'], inplace=True)
+    result.reset_index(drop=True, inplace=True)
+    return result
+
+def show_brief(dataframe: pd.DataFrame) -> pd.DataFrame:
+    brief_df = dataframe
+    n = len(dataframe)
+    if n >= 4:
+        last = n - 1
+        brief_df = dataframe.loc[[0, 1, last - 1, last]]
+    logger.info(brief_df)
+    # logger.info(f"DateTime type {brief_df.loc[0]['date']} = {type(brief_df.loc[0]['date'])}")
+        
+def download_and_merge_if_exists_historical_data_single_ticker(ticker: str) -> pd.DataFrame:
+    new_df: pd.DataFrame = download_trading_view_data(ticker)
+    if new_df.empty:
+        logger.warn(f"download_and_merge operation failed for ticker {ticker}: Failed to download Trading View data")
+        return new_df
+    perform_data_transfomration(new_df)
+    
+    logger.info("Downloaded dataframe")
+    show_brief(new_df)
+    
+    file = get_portfolio_historical_data_csv(ticker)
+    existing_df = pd.DataFrame()
+    if file.exists():
+        existing_df = pd.read_csv(file, index_col=False)
+        perform_data_transfomration(existing_df)
+    
+    logger.info("Existing dataframe")
+    show_brief(existing_df)
+    
+    df = merge_dataframes(new_df, existing_df)
+    
+    logger.info(f"Saving dataframe to {file.as_posix()}")
+    df.to_csv(file, index=False)
+    return df
+
+def download_historical_data(tickers: list[str]):
+    for ticker in tickers:
+        download_historical_data_single_ticker(ticker)
+
+def worker_fun(ticker: str) -> typing.Optional[str]:
+    """
+    if download fails for ticker then tocker is returned
+    Otherwise None is returned
+    """
+    dataframe: pd.DataFrame = download_and_merge_if_exists_historical_data_single_ticker(ticker)
+    if dataframe.empty:
+        return ticker
+    
+def download_and_merge_historical_data(tickers: list[str]) -> list[str]:
+    failed_tickers: list[str] = list()
+    # if the num of workers is 10 we get 429 too many requests error status code
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+    
+    futures: dict[concurrent.futures.Future, str] = {
+        executor.submit(worker_fun, ticker): ticker for ticker in tickers
+    }
+    for future in concurrent.futures.as_completed(futures):
+        try:
+            result = future.result()
+            if result:
+                failed_tickers.append(result)
+        except Exception as exc:
+            ticker: str = futures.get(future)
+            logger.error(f"Failed to download Trading view data for ticker {ticker}", exc)
+            failed_tickers.append(ticker)
+    
+    if len(failed_tickers) > 0:
+        logger.warn(f"download_and_merge_historical_data. Failed to download new data for tickers {failed_tickers}")
+    return failed_tickers
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,8 @@
 from pathlib import Path
+import sys
+
+# add bvb_finance project path in tests
+sys.path.append(Path(__file__).parent.parent)
 
 resources = 'resources'
 

--- a/tests/portfolio/test_portfolio.py
+++ b/tests/portfolio/test_portfolio.py
@@ -5,7 +5,7 @@ from bvb_finance.portfolio import loaders
 from bvb_finance.portfolio import dto
 from bvb_finance import portfolio
 from bvb_finance.portfolio.acquistions_processor import AcquisitionsProcessor
-from . import get_full_path
+from .. import get_full_path
 
 class TestPortfolio(unittest.TestCase):
     def test_acquistion_types(self):

--- a/tests/portfolio/test_portfolio_merge_dataframes.py
+++ b/tests/portfolio/test_portfolio_merge_dataframes.py
@@ -1,0 +1,62 @@
+import unittest
+import datetime
+import pandas as pd
+from bvb_finance.portfolio import trading_view
+
+class TestPortfolio(unittest.TestCase):
+    def test_identical_frames(self):
+        frame: pd.DataFrame = pd.DataFrame([
+            [datetime.date(2010, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2011, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2012, 12, 22), 'BBB', 1, 10, 0.2, 9, 100]
+            ],
+            columns = ['date', 'symbol', 'open', 'high', 'low', 'close', 'volume'])
+        
+        duplicate: pd.DataFrame = frame.copy(deep=True)
+        result: pd.DataFrame = trading_view.merge_dataframes(frame, duplicate)
+        diff: pd.DataFrame = frame.compare(result)
+        self.assertTrue(diff.empty)
+    
+    def _test_merge(self, frame1):
+        frame2: pd.DataFrame = pd.DataFrame([
+            [datetime.date(2010, 12, 22), 'BBB', 2, 20, 2.2, 2, 200],
+            [datetime.date(2020, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2021, 12, 22), 'BBB', 1, 10, 0.2, 9, 100]
+            ],
+            columns = ['date', 'symbol', 'open', 'high', 'low', 'close', 'volume'])
+        expected: pd.DataFrame = pd.DataFrame([
+            [datetime.date(2010, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2011, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2012, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2020, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2021, 12, 22), 'BBB', 1, 10, 0.2, 9, 100]
+            ],
+            columns = ['date', 'symbol', 'open', 'high', 'low', 'close', 'volume'])
+        result: pd.DataFrame = trading_view.merge_dataframes(frame1, frame2)
+        self.assertEqual(list(expected.index), list(range(len(expected))))
+        self.assertEqual(list(expected.index), list(result.index))
+        
+        diff: pd.DataFrame = expected.compare(result)
+        self.assertTrue(diff.empty)
+
+    def test_common_records_do_not_appear_twice_datetime_date(self):
+        frame1: pd.DataFrame = pd.DataFrame([
+            [datetime.date(2010, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2011, 12, 22), 'BBB', 1, 10, 0.2, 9, 100],
+            [datetime.date(2012, 12, 22), 'BBB', 1, 10, 0.2, 9, 100]
+            ],
+            columns = ['date', 'symbol', 'open', 'high', 'low', 'close', 'volume'])
+        self._test_merge(frame1)
+    
+    def test_common_records_do_not_appear_twice_pd_Timestamp(self):
+        frame1: pd.DataFrame = pd.DataFrame([
+            [pd.Timestamp(year=2010, month=12, day=22), 'BBB', 1, 10, 0.2, 9, 100],
+            [pd.Timestamp(year=2011, month=12, day=22), 'BBB', 1, 10, 0.2, 9, 100],
+            [pd.Timestamp(year=2012, month=12, day=22), 'BBB', 1, 10, 0.2, 9, 100]
+            ],
+            columns = ['date', 'symbol', 'open', 'high', 'low', 'close', 'volume'])
+        # adjusts timestamps to datetime.date
+        trading_view.perform_data_transfomration(frame1)
+        self._test_merge(frame1)
+        
+        


### PR DESCRIPTION
Add functionality to merge historical data for each ticket. 
Data is fetched from Trading View 500 records, weekly frequency
When data is fetched multiple times the existibg functionality allow the previously collected data to me merge into the mewly collected data, thus saving in csv file more than 500 records
The csv file is overwritten

Also in this PR:
 - organize test files into packages